### PR TITLE
fix: add complete endponit at folder path

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,10 +65,9 @@ logcat.stdout.on("data", function (data) {
     // ---- http.txt
     // ---- payload.json
 
-    const folderName = `${new Date().getTime()}-${httpMethod}-${endpoint.replace(
-      "https://",
-      ""
-    )}`;
+    const folderName = `${new Date().getTime()}-${httpMethod}-${endpoint
+      .replace("https://", "")
+      .replace(/\//g, "\\")}`;
 
     const folderDir = path.join("./data", folderName);
 
@@ -88,7 +87,7 @@ logcat.stdout.on("data", function (data) {
     const payloadResponse = response.match(payloadResponseRegex);
 
     if (payloadResponse) {
-      let content = payloadResponse[0].replace("<--", "").replaceAll("\n", "");
+      let content = payloadResponse[0].replace("<--", "").replace(/\n/g, "");
       const filePath = path.join(folderDir, "response", "payload.json");
 
       saveJsonFile(filePath, content);


### PR DESCRIPTION
- Adição de regex substituindo o caractere `/` por `\` no `folderName`. Dessa forma, as pastas ficam com o nome do endpoint inteiro:
![image](https://github.com/tiomaeduardo-rethink/http-discovery-android/assets/86979941/9fe6825c-595c-4d77-bc44-808a50fcc201)
- Troca do método `replaceAll` por apenas `replace`, pois o primeiro só funciona em versões mais recentes do node